### PR TITLE
🏷 OCI: set repo URL.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,7 @@
 FROM alpine
 
-LABEL org.opencontainers.image.authors="Alan Ip <theipster@users.noreply.github.com>"
+LABEL org.opencontainers.image.authors="Alan Ip <theipster@users.noreply.github.com>" \
+    org.opencontainers.image.source="https://github.com/theipster/aws-cloudformation-graphviz"
 
 # Init user, install packages
 RUN addgroup -S app && \


### PR DESCRIPTION
This is how GitHub expects image artifacts (packages) to be linked back
to its source repo.

See https://docs.github.com/en/free-pro-team@latest/packages/guides/connecting-a-repository-to-a-container-image