### PR TITLE
⚡ Micro-optimise container image.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,11 +10,11 @@ RUN addgroup -S app && \
 
 # Download AWS icon pack
 RUN wget https://d1.awsstatic.com/webteam/architecture-icons/AWS-Architecture-Icons_PNG_20200430.1f43d2dd713164497d228e77bd7542ff7b504bd4.zip -O aws-png-icons.zip && \
-    echo "1f43d2dd713164497d228e77bd7542ff7b504bd4  aws-png-icons.zip" > aws-png-icons.zip.sha1sum && \
-    sha1sum -c aws-png-icons.zip.sha1sum && \
-    mkdir /var/cache/aws-png-icons/ && \
-    unzip -jnq aws-png-icons.zip -d /var/cache/aws-png-icons/ && \
-    du -sc /var/cache/aws-png-icons/
+    echo "1f43d2dd713164497d228e77bd7542ff7b504bd4  aws-png-icons.zip" | sha1sum -c && \
+    mkdir -v /var/cache/aws-png-icons/ && \
+    unzip -jnq aws-png-icons.zip -x */.DS_Store */._* -d /var/cache/aws-png-icons/ && \
+    du -sh /var/cache/aws-png-icons/ && \
+    rm -v aws-png-icons.zip
 
 # Copy executables
 WORKDIR /etc/aws-cloudformation-graphviz

--- a/tests.sh
+++ b/tests.sh
@@ -4,19 +4,19 @@
 suite=`find . -type f -name *.test.sh | sort`
 
 # Begin
-echo "Running test suite: (`echo "$suite" | wc -l` found)"
-echo "===="
+echo "Test suite started (`echo "$suite" | wc -l` found) 🤞"
+echo "========"
 
 # Run tests (fail fast)
 for test in $suite; do
   dir=`dirname "$test"`
   file=`basename "$test"`
-  (cd "$dir" && echo -n "$dir: " && . "$file" && echo " ✔")
+  (cd "$dir" && echo -n "$dir: " && . "$file" && echo " ✅")
   if [ "$?" != 0 ]; then
     echo " ❌" && exit 1
   fi
 done
 
 # Done
-echo "===="
+echo "========"
 echo "Test suite complete. 👌"


### PR DESCRIPTION
Shaves 24% (15.7M) off the image size.

- Run `sha1sum` through stdin, rather than saving to disk [speed].
- Be verbose when making the icons dir, for logs [visibility].
- Skip Mac metadata files (e.g. `.DS_Store`, etc.) [size].
- Remove duplicate summary line on extraction complete [visibility].
- Bin off the raw zip file after extraction [size].