### PR TITLE
🏷 OCI: set versioning details.

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -23,6 +23,8 @@ jobs:
       - name: Build (and tag)
         run: |
           docker build . \
+            --label org.opencontainers.image.created="$(date --rfc-3339=seconds --utc)" \
+            --label org.opencontainers.image.revision=$GITHUB_SHA \
             --tag ${{ env.REGISTRY }}/$GITHUB_REPOSITORY:$GITHUB_SHA \
             --tag ${{ env.REGISTRY }}/$GITHUB_REPOSITORY:latest
 


### PR DESCRIPTION
This allows some form of version tracking once distributed.